### PR TITLE
compression modification

### DIFF
--- a/lib/jose/jwe/zip_def.rb
+++ b/lib/jose/jwe/zip_def.rb
@@ -18,11 +18,19 @@ class JOSE::JWE::ZIP_DEF
   # JOSE::JWE::ZIP callbacks
 
   def compress(plain_text)
-    return Zlib.deflate(plain_text)
+    zstream = Zlib::Deflate.new(nil, -Zlib::MAX_WBITS)
+    buf = zstream.deflate(plain_text, Zlib::FINISH)
+    zstream.finish
+    zstream.close
+    return buf
   end
 
   def uncompress(cipher_text)
-    return Zlib.inflate(cipher_text)
+    zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+    buf = zstream.inflate(cipher_text)
+    zstream.finish
+    zstream.close
+    return buf
   end
 
 end


### PR DESCRIPTION
updating compress and uncompress methods to follow the RFC 1951 standard,

from what I can tell, ZLib wraps the data (RFC 1950 around RFC 1951) making
it incompatible with other libraries
https://tools.ietf.org/html/draft-ietf-jose-json-web-encryption-10#section-4.1.4
http://stackoverflow.com/questions/15632979/java-decompressing-array-of-bytes